### PR TITLE
[PROD-775] Update farm reward in dashboard

### DIFF
--- a/src/components/BurgerMenu/LiquidityReward.tsx
+++ b/src/components/BurgerMenu/LiquidityReward.tsx
@@ -2,11 +2,10 @@ import { Box, IconButton } from "@mui/material";
 import { ReactElement } from "react";
 import { useModal } from "providers/modal";
 import CloseIcon from "@mui/icons-material/Close";
-import { PoolConfig, poolConfigs } from "constants/deployConfigV2";
 import RewardCard from "views/Reward/components/RewardCard";
 
 const LiquidityReward = (props): ReactElement => {
-  const { handleClaimFarmRewards } = props;
+  const { handleClaimFarmRewards, farmPoolInfoList } = props;
   const { setMenu } = useModal();
   return (
     <Box width="100%" minWidth={{ md: 460 }}>
@@ -19,16 +18,14 @@ const LiquidityReward = (props): ReactElement => {
         </IconButton>
       </Box>
       <Box maxHeight={500} sx={{ overflow: "auto" }}>
-        {poolConfigs.map((poolConfig: PoolConfig) =>
-          poolConfig.farmInfoList?.map((farm) => (
-            <RewardCard
-              key={poolConfig.name + "-reward"}
-              poolConfig={poolConfig}
-              farmPoolAddress={farm.farmInfo}
-              handleClaimFarmRewards={handleClaimFarmRewards}
-            />
-          )),
-        )}
+        {farmPoolInfoList.map(({ poolConfig, farmInfo }) => (
+          <RewardCard
+            key={poolConfig.name + "-reward"}
+            poolConfig={poolConfig}
+            farmPoolAddress={farmInfo}
+            handleClaimFarmRewards={handleClaimFarmRewards}
+          />
+        ))}
       </Box>
     </Box>
   );

--- a/src/components/Modal/ModalMenu.tsx
+++ b/src/components/Modal/ModalMenu.tsx
@@ -64,7 +64,7 @@ export default function ModalMenu() {
       case "liquidity-reward":
         return (
           <LiquidityReward
-            farmPoolRewardsInfo={data?.farmPoolRewardsInfo}
+            farmPoolInfoList={data?.farmPoolInfoList}
             handleClaimFarmRewards={
               data?.handleClaimFarmRewards || (() => console.error("no handler"))
             }

--- a/src/states/accounts/farmUserAccount.ts
+++ b/src/states/accounts/farmUserAccount.ts
@@ -7,10 +7,12 @@ import { FarmUser } from "anchor/type_definitions";
 type FarmPoolKeyToFarmUser = Record<string, FarmUser>;
 export interface FarmUserState {
   farmPoolKeyToFarmUser: FarmPoolKeyToFarmUser;
+  fetched: boolean;
 }
 
 const initialState: FarmUserState = {
   farmPoolKeyToFarmUser: {},
+  fetched: false,
 };
 
 type FetchFarmUsersThunkArg = {
@@ -65,5 +67,6 @@ export const fetchFarmUsersThunk = createAsyncThunk(
 export const farmUserAccountReducer = createReducer(initialState, (builder) => {
   builder.addCase(fetchFarmUsersThunk.fulfilled, (state, action) => {
     state.farmPoolKeyToFarmUser = action.payload.farmPoolKeyToFarmUser;
+    state.fetched = true;
   });
 });

--- a/src/states/selectors.ts
+++ b/src/states/selectors.ts
@@ -9,11 +9,12 @@ export const poolSelector = (state: RootState) => state.accounts.swapAccount;
 export const pythSelector = (state: RootState) => state.accounts.pythAccount;
 export const tokenAccountSelector = (state: RootState) => state.accounts.tokenAccount;
 export const deltafiUserSelector = (state: RootState) => state.accounts.deltafiUserAccount;
-export const farmUserSelector = (state: RootState) =>
-  state.accounts.farmUserAccount.farmPoolKeyToFarmUser;
+export const farmUserSelector = (state: RootState) => state.accounts.farmUserAccount;
 export const farmSelector = (state: RootState) => state.accounts.farmAccount.farmKeyToFarmInfo;
 
 export const depositViewSelector = (state: RootState) => state.views.depositView;
+export const dashboardViewSelector = (state: RootState) => state.views.dashboardView;
+
 export const swapViewSelector = (state: RootState) => state.views.swapView;
 export const rewardViewSelector = (state: RootState) => state.views.rewardView;
 export const stakeViewSelector = (state: RootState) => state.views.stakeView;

--- a/src/states/views/dashboardView.ts
+++ b/src/states/views/dashboardView.ts
@@ -1,0 +1,24 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import BigNumber from "bignumber.js";
+
+const initialState = {
+  totalDelfiRewards: null,
+  selectedTab: "reward",
+};
+
+const dashboardViewSlice = createSlice({
+  name: "dashboardView",
+  initialState,
+  reducers: {
+    setSelectedTab(state, action: PayloadAction<{ selectedTab: string }>) {
+      state.selectedTab = action.payload.selectedTab;
+    },
+
+    setTotalDelfiRewards(state, action: PayloadAction<{ totalDelfiRewards: BigNumber }>) {
+      state.totalDelfiRewards = action.payload.totalDelfiRewards;
+    },
+  },
+});
+
+export const dashboardViewReducer = dashboardViewSlice.reducer;
+export const dashboardViewActions = dashboardViewSlice.actions;

--- a/src/states/views/index.ts
+++ b/src/states/views/index.ts
@@ -1,4 +1,5 @@
 import { combineReducers } from "@reduxjs/toolkit";
+import { dashboardViewReducer } from "./dashboardView";
 import { depositViewReducer } from "./depositView";
 import { rewardViewReducer } from "./rewardView";
 import { stakeViewReducer } from "./stakeView";
@@ -9,4 +10,5 @@ export const viewsReducer = combineReducers({
   swapView: swapViewReducer,
   rewardView: rewardViewReducer,
   stakeView: stakeViewReducer,
+  dashboardView: dashboardViewReducer,
 });

--- a/src/states/views/rewardView.ts
+++ b/src/states/views/rewardView.ts
@@ -1,5 +1,4 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import BigNumber from "bignumber.js";
 
 type FarmPoolToRewards = Record<
   string,

--- a/src/states/views/rewardView.ts
+++ b/src/states/views/rewardView.ts
@@ -20,7 +20,6 @@ const initialState = {
   claimResult: null,
   farmPoolToRewards: {},
   rewardRefreshTs: Math.floor(Date.now() / 1000),
-  totalDelfiRewards: new BigNumber(0),
 };
 
 const rewardViewSlice = createSlice({

--- a/src/states/views/rewardView.ts
+++ b/src/states/views/rewardView.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import BigNumber from "bignumber.js";
 
 type FarmPoolToRewards = Record<
   string,
@@ -19,6 +20,7 @@ const initialState = {
   claimResult: null,
   farmPoolToRewards: {},
   rewardRefreshTs: Math.floor(Date.now() / 1000),
+  totalDelfiRewards: new BigNumber(0),
 };
 
 const rewardViewSlice = createSlice({

--- a/src/views/Dashboard/Home.tsx
+++ b/src/views/Dashboard/Home.tsx
@@ -240,7 +240,12 @@ const Home: React.FC = (props) => {
     if (!isConnectedWallet) {
       return { totalRewards: null, isLoadingTotalRewards: false };
     }
-    if (!deltafiUser.fetched || !isFarmUserFetched || !deltafiPrice) {
+    if (
+      !deltafiUser.fetched ||
+      !isFarmUserFetched ||
+      !deltafiPrice ||
+      !dashboardView.totalDelfiRewards
+    ) {
       // when wallet is connected, but deltafiUser is not fetched yet
       return { totalRewards: null, isLoadingTotalRewards: true };
     }

--- a/src/views/Dashboard/Home.tsx
+++ b/src/views/Dashboard/Home.tsx
@@ -16,7 +16,7 @@ import Page from "components/layout/Page";
 import { PoolConfig, poolConfigs } from "constants/deployConfigV2";
 import PoolCard from "views/Pool/components/Card_v2";
 import FarmCard from "views/Farm/components/Card";
-import { ChangeEvent, useCallback, useMemo, useState } from "react";
+import { ChangeEvent, useCallback, useMemo } from "react";
 import Reward from "views/Reward";
 import { MintToTokenAccountInfo } from "states/accounts/tokenAccount";
 import { useDispatch, useSelector } from "react-redux";
@@ -27,7 +27,6 @@ import {
   pythSelector,
   deltafiUserSelector,
   selectGateIoSticker,
-  rewardViewSelector,
   dashboardViewSelector,
   farmUserSelector,
 } from "states/selectors";
@@ -36,8 +35,6 @@ import BigNumber from "bignumber.js";
 import { getPythMarketPrice } from "states/accounts/pythAccount";
 import { calculateWithdrawalFromShares } from "lib/calc";
 import { formatCurrencyAmount } from "utils/utils";
-import { exponentiatedBy } from "utils/decimal";
-import { DELTAFI_TOKEN_DECIMALS } from "constants/deployConfigV2";
 import { CircularProgress } from "@material-ui/core";
 import { dashboardViewActions } from "states/views/dashboardView";
 

--- a/src/views/Reward/Home.tsx
+++ b/src/views/Reward/Home.tsx
@@ -394,7 +394,7 @@ const Home: React.FC = (props) => {
             .map((farm) => ({ poolConfig, farmInfo: farm.farmInfo })),
         )
         .flat(),
-    [poolConfigs, farmPoolKeyToFarmUser, farmPoolToRewards],
+    [farmPoolKeyToFarmUser, farmPoolToRewards],
   );
 
   const handleSnackBarClose = useCallback(() => {
@@ -539,7 +539,15 @@ const Home: React.FC = (props) => {
       dispatch(rewardViewActions.setIsClaimingFarmRewards({ isClaimingFarmRewards: false }));
       dispatch(fetchFarmUsersThunk({ connection, walletAddress: walletPubkey }));
     }
-  }, [dispatch, farmPoolKeyToFarmUser, program, signTransaction, userDeltafiToken, walletPubkey]);
+  }, [
+    dispatch,
+    program,
+    signTransaction,
+    userDeltafiToken,
+    walletPubkey,
+    farmPoolInfoList,
+    farmPoolToRewards,
+  ]);
 
   const claimFarmRewardsButton = useMemo(() => {
     return (
@@ -577,7 +585,7 @@ const Home: React.FC = (props) => {
     setMenu,
     userUnclaimedFarmRewards,
     userTotalFarmRewards,
-    farmPoolToRewards,
+    farmPoolInfoList,
     handleClaimFarmRewards,
   ]);
 

--- a/src/views/Reward/Home.tsx
+++ b/src/views/Reward/Home.tsx
@@ -388,16 +388,21 @@ const Home: React.FC = (props) => {
       poolConfigs
         .map((poolConfig: PoolConfig) =>
           poolConfig.farmInfoList
-            .filter(
-              (farm) =>
-                !!farmPoolKeyToFarmUser[farm.farmInfo] &&
-                ((farmPoolKeyToFarmUser[farm.farmInfo].basePosition.depositedAmount.gt(new BN(0)) &&
-                  farmPoolKeyToFarmUser[farm.farmInfo].quotePosition.depositedAmount.gt(
-                    new BN(0),
-                  )) ||
-                  parseFloat(farmPoolToRewards[farm.farmInfo].unclaimedFarmRewards) > 0) &&
-                farmPoolToRewards[farm.farmInfo].totalFarmRewards !== "--",
-            )
+            .filter(({ farmInfo }) => {
+              const farmUser = farmPoolKeyToFarmUser[farmInfo];
+              if (!farmUser) {
+                return false;
+              }
+
+              const hasStakedShares =
+                farmUser.basePosition.depositedAmount.gt(new BN(0)) ||
+                farmUser.quotePosition.depositedAmount.gt(new BN(0));
+
+              const hasUnclaimedRewards =
+                parseFloat(farmPoolToRewards[farmInfo].unclaimedFarmRewards) > 0;
+
+              return hasStakedShares || hasUnclaimedRewards;
+            })
             .map((farm) => ({ poolConfig, farmInfo: farm.farmInfo })),
         )
         .flat(),

--- a/src/views/Reward/Home.tsx
+++ b/src/views/Reward/Home.tsx
@@ -391,8 +391,12 @@ const Home: React.FC = (props) => {
             .filter(
               (farm) =>
                 !!farmPoolKeyToFarmUser[farm.farmInfo] &&
-                farmPoolToRewards[farm.farmInfo].totalFarmRewards !== "--" &&
-                farmPoolToRewards[farm.farmInfo].unclaimedFarmRewards !== "--",
+                ((farmPoolKeyToFarmUser[farm.farmInfo].basePosition.depositedAmount.gt(new BN(0)) &&
+                  farmPoolKeyToFarmUser[farm.farmInfo].quotePosition.depositedAmount.gt(
+                    new BN(0),
+                  )) ||
+                  parseFloat(farmPoolToRewards[farm.farmInfo].unclaimedFarmRewards) > 0) &&
+                farmPoolToRewards[farm.farmInfo].totalFarmRewards !== "--",
             )
             .map((farm) => ({ poolConfig, farmInfo: farm.farmInfo })),
         )

--- a/src/views/Reward/Home.tsx
+++ b/src/views/Reward/Home.tsx
@@ -278,7 +278,7 @@ const Home: React.FC = (props) => {
         farmUser.basePosition.rewardsOwed.toString(),
         DELTAFI_TOKEN_DECIMALS,
       );
-      const unTrackedBaseRewards = getUntrackedReward(
+      const untrackedBaseRewards = getUntrackedReward(
         rewardView.rewardRefreshTs,
         farmUser.basePosition.lastUpdateTs.toNumber(),
         farmUser.basePosition.nextClaimTs.toNumber(),
@@ -295,7 +295,7 @@ const Home: React.FC = (props) => {
         farmUser.quotePosition.rewardsOwed.toString(),
         DELTAFI_TOKEN_DECIMALS,
       );
-      const unTrackedQuoteRewards = getUntrackedReward(
+      const untrackedQuoteRewards = getUntrackedReward(
         rewardView.rewardRefreshTs,
         farmUser.quotePosition.lastUpdateTs.toNumber(),
         farmUser.quotePosition.nextClaimTs.toNumber(),
@@ -308,10 +308,13 @@ const Home: React.FC = (props) => {
         DELTAFI_TOKEN_DECIMALS,
       );
 
+      const untrackedRewards =
+        untrackedBaseRewards.isEqualTo(0) || untrackedQuoteRewards.isEqualTo(0)
+          ? new BigNumber(0)
+          : untrackedBaseRewards.plus(untrackedQuoteRewards);
       const unclaimedFarmRewards = owedBaseRewards
         .plus(owedQuoteRewards)
-        .plus(unTrackedBaseRewards)
-        .plus(unTrackedQuoteRewards)
+        .plus(untrackedRewards)
         .toFixed(DELTAFI_TOKEN_DECIMALS);
       const totalFarmRewards = claimedBaseRewards
         .plus(claimedQuoteRewards)

--- a/src/views/Reward/Home.tsx
+++ b/src/views/Reward/Home.tsx
@@ -51,6 +51,7 @@ import styled from "styled-components";
 import { fetchFarmUsersThunk } from "states/accounts/farmUserAccount";
 import { scheduleWithInterval } from "utils";
 import { anchorBnToBn } from "utils/tokenUtils";
+import { dashboardViewActions } from "states/views/dashboardView";
 
 const useStyles = makeStyles(({ palette, breakpoints, spacing }: Theme) => ({
   root: {
@@ -200,7 +201,7 @@ const Home: React.FC = (props) => {
   const rewardView = useSelector(rewardViewSelector);
   const deltafiUser = useSelector(deltafiUserSelector);
 
-  const farmPoolKeyToFarmUser = useSelector(farmUserSelector);
+  const farmPoolKeyToFarmUser = useSelector(farmUserSelector).farmPoolKeyToFarmUser;
   const farmKeyToFarmInfo = useSelector(farmSelector);
 
   const userDeltafiToken = useSelector(selectTokenAccountInfoByMint(deployConfigV2.deltafiMint));
@@ -214,11 +215,6 @@ const Home: React.FC = (props) => {
     apr: BigNumber,
     depositAmount: BigNumber,
   ) => {
-    console.log("ts diff", currentTs - lastUpdateTs);
-    console.log("currentTs", currentTs);
-    console.log("nextClaimTs", nextClaimTs);
-    console.log("apr", apr.toString());
-    console.log("depositAmount", depositAmount.toString());
     if (lastUpdateTs >= currentTs || currentTs <= nextClaimTs) {
       return new BigNumber(0);
     }
@@ -367,6 +363,22 @@ const Home: React.FC = (props) => {
       totalRewardFromReferral: "--",
     };
   }, [deltafiUser]);
+
+  useEffect(() => {
+    const totalRewardFromReferralBn =
+      totalRewardFromReferral === "--" ? new BigNumber(0) : new BigNumber(totalRewardFromReferral);
+    const totalRewardFromSwapBn =
+      totalRewardFromSwap === "--" ? new BigNumber(0) : new BigNumber(totalRewardFromSwap);
+    const userTotalFarmRewardsBn =
+      userTotalFarmRewards === "--" ? new BigNumber(0) : new BigNumber(userTotalFarmRewards);
+    dispatch(
+      dashboardViewActions.setTotalDelfiRewards({
+        totalDelfiRewards: totalRewardFromReferralBn
+          .plus(totalRewardFromSwapBn)
+          .plus(userTotalFarmRewardsBn),
+      }),
+    );
+  }, [totalRewardFromSwap, totalRewardFromReferral, userTotalFarmRewards, dispatch]);
 
   const farmPoolInfoList = useMemo(
     () =>

--- a/src/views/Reward/components/RewardCard.tsx
+++ b/src/views/Reward/components/RewardCard.tsx
@@ -138,7 +138,7 @@ const Card: React.FC<CardProps> = (props) => {
     <Box
       fontSize={{ md: 14, xs: 12 }}
       padding={{ md: 2.5, xs: 1 }}
-      minWidth={{ md: 480 }}
+      minWidth={{ md: 560 }}
       mt={1.25}
       lineHeight={1}
       sx={{
@@ -179,11 +179,10 @@ const Card: React.FC<CardProps> = (props) => {
             <Box color="#D3D3D3" fontWeight={500} whiteSpace="nowrap">
               Unclaimed / Total
             </Box>
-            {/* TODO replace the placeholder with real data */}
             <Box
               mt={1}
               display="flex"
-              fontSize={{ xs: 14, md: 18 }}
+              fontSize={{ xs: 12, md: 16 }}
               fontWeight={500}
               sx={{
                 whiteSpace: "nowrap",

--- a/src/views/Stake/Stake_v2.tsx
+++ b/src/views/Stake/Stake_v2.tsx
@@ -217,6 +217,7 @@ const Stake = (): ReactElement => {
         poolConfig.quoteTokenInfo,
         stakeView.stake.quoteSelected.toString(),
       );
+
       const transaction = await createUpdateStakeTransaction(
         program,
         connection,


### PR DESCRIPTION
1. Include farm rewards to total rewards
![Screen Shot 1401-03-25 at 16 10 04](https://user-images.githubusercontent.com/96594219/173957256-beef5266-0410-4afa-8b8b-e9029c795a80.png)
2. Only add staked farm pool to claim farm reward panel
3. made the panel wider to avoid overlap between the number and button
4. Also filter out the staked farm user for transaction
![Screen Shot 1401-03-25 at 16 10 20](https://user-images.githubusercontent.com/96594219/173957272-68583a05-2824-4019-adb1-fe9d4bc074f0.png)

TODO: the total reward is calculated in Reward page and updated to dashboardView for dashboard page to display it. Need to refactor the code to make total rewards calculated with the dashboard page