### PR TITLE
Refactor pyth redux state with new utils

### DIFF
--- a/src/anchor/idl/deltafi_dex_v2.json
+++ b/src/anchor/idl/deltafi_dex_v2.json
@@ -2989,8 +2989,5 @@
       "name": "InvalidStakingAmount",
       "msg": "Invalid staking amount"
     }
-  ],
-  "metadata": {
-    "address": "HcWvS1XyweYMrCvY8TEeDxXgbWJagizUZXxCSLC2E89N"
-  }
+  ]
 }

--- a/src/anchor/idl/deltafi_dex_v2.json
+++ b/src/anchor/idl/deltafi_dex_v2.json
@@ -2989,5 +2989,8 @@
       "name": "InvalidStakingAmount",
       "msg": "Invalid staking amount"
     }
-  ]
+  ],
+  "metadata": {
+    "address": "HcWvS1XyweYMrCvY8TEeDxXgbWJagizUZXxCSLC2E89N"
+  }
 }

--- a/src/anchor/pyth_utils.ts
+++ b/src/anchor/pyth_utils.ts
@@ -42,6 +42,14 @@ export function getPythMarketPriceTuple(
   const basePythPriceData = symbolToPythPriceData[baseSymbol];
   const quotePythPriceData = symbolToPythPriceData[quoteSymbol];
 
+  if (!basePythPriceData || quotePythPriceData) {
+    return {
+      marketPrice: new BigNumber(NaN),
+      lowPrice: new BigNumber(NaN),
+      highPrice: new BigNumber(NaN),
+    };
+  }
+
   const marketPrice = new BigNumber(basePythPriceData.price).dividedBy(
     new BigNumber(quotePythPriceData.price),
   );

--- a/src/anchor/pyth_utils.ts
+++ b/src/anchor/pyth_utils.ts
@@ -34,7 +34,7 @@ export async function getSymbolToPythPriceData(
   return symbolToPythPriceData;
 }
 
-export function getMarketPriceTuple(
+export function getPythMarketPriceTuple(
   symbolToPythPriceData: SymbolToPythPriceData,
   baseSymbol: string,
   quoteSymbol: string,

--- a/src/calculations/swapOutAmount.ts
+++ b/src/calculations/swapOutAmount.ts
@@ -3,7 +3,7 @@ import { calculateOutAmountNormalSwap, calculateOutAmountStableSwap } from "./ca
 import { PoolState, SwapConfig, SwapInfo, SwapDirection } from "../anchor/type_definitions";
 import { WAD, bnToString, exponentiate, exponentiatedBy } from "./utils";
 import { TokenConfig } from "./types";
-import { getMarketPriceTuple, SymbolToPythPriceData } from "../anchor/pyth_utils";
+import { getPythMarketPriceTuple, SymbolToPythPriceData } from "../anchor/pyth_utils";
 
 export type SwapOutResult = {
   amountIn: string;
@@ -38,7 +38,7 @@ export async function getSwapOutResult(
       ? { baseToken: fromToken, quoteToken: toToken }
       : { baseToken: toToken, quoteToken: fromToken };
 
-  const marketPriceTuple = getMarketPriceTuple(
+  const marketPriceTuple = getPythMarketPriceTuple(
     symbolToPythPriceData,
     baseToken.symbol,
     quoteToken.symbol,

--- a/src/lib/calc/pools.ts
+++ b/src/lib/calc/pools.ts
@@ -1,3 +1,4 @@
+import { SymbolToPythPriceData } from "anchor/pyth_utils";
 import BigNumber from "bignumber.js";
 import { PoolConfig } from "constants/deployConfigV2";
 import { getPythMarketPrice, SymbolToPythData } from "states/accounts/pythAccount";
@@ -7,7 +8,7 @@ import { getTokenTvl } from "utils/utils";
 export function calculateTotalHoldings(
   poolConfigs: PoolConfig[],
   swapKeyToSwapInfo: SwapPoolKeyToSwap,
-  symbolToPythData: SymbolToPythData,
+  symbolToPythData: SymbolToPythPriceData,
 ) {
   if (poolConfigs.length > 0) {
     return (poolConfigs as any).reduce((sum, poolConfig) => {

--- a/src/lib/calc/pools.ts
+++ b/src/lib/calc/pools.ts
@@ -1,7 +1,7 @@
 import { SymbolToPythPriceData } from "anchor/pyth_utils";
 import BigNumber from "bignumber.js";
 import { PoolConfig } from "constants/deployConfigV2";
-import { getPythMarketPrice, SymbolToPythData } from "states/accounts/pythAccount";
+import { getPythMarketPrice } from "states/accounts/pythAccount";
 import { SwapPoolKeyToSwap } from "states/accounts/swapAccount";
 import { getTokenTvl } from "utils/utils";
 

--- a/src/lib/calc/pools.ts
+++ b/src/lib/calc/pools.ts
@@ -8,12 +8,12 @@ import { getTokenTvl } from "utils/utils";
 export function calculateTotalHoldings(
   poolConfigs: PoolConfig[],
   swapKeyToSwapInfo: SwapPoolKeyToSwap,
-  symbolToPythData: SymbolToPythPriceData,
+  symbolToPythPriceData: SymbolToPythPriceData,
 ) {
   if (poolConfigs.length > 0) {
     return (poolConfigs as any).reduce((sum, poolConfig) => {
       const swapInfo = swapKeyToSwapInfo[poolConfig.swapInfo];
-      const { basePrice, quotePrice } = getPythMarketPrice(symbolToPythData, poolConfig);
+      const { basePrice, quotePrice } = getPythMarketPrice(symbolToPythPriceData, poolConfig);
 
       let volumn = new BigNumber(0);
       if (basePrice && quotePrice && swapInfo) {

--- a/src/states/accounts/pythAccount.ts
+++ b/src/states/accounts/pythAccount.ts
@@ -151,3 +151,30 @@ export function getPythMarketPrice(symbolToPythData: SymbolToPythData, poolConfi
     marketPriceHigh,
   };
 }
+
+export function getPythPrice(
+  symbolToPythPriceData: SymbolToPythPriceData,
+  tokenSymbol: string | null | undefined,
+) {
+  let result = { price: null, confidenceInterval: null };
+  if (!tokenSymbol) {
+    return result;
+  }
+
+  if (!symbolToPythPriceData[tokenSymbol]) {
+    return result;
+  }
+
+  const priceData = symbolToPythPriceData[tokenSymbol];
+  result = {
+    price: priceData.price,
+    confidenceInterval: priceData.confidence,
+  };
+
+  // if the price and confidence interval are both not undefined, price should be greater than confidence interval
+  validate(
+    !(result.price && result.confidenceInterval) || result.price > result.confidenceInterval,
+    "confidence interval should not be larger than the price",
+  );
+  return result;
+}

--- a/src/states/accounts/pythAccount.ts
+++ b/src/states/accounts/pythAccount.ts
@@ -48,7 +48,10 @@ export const fetchPythDataThunk = createAsyncThunk(
       for (const pythData of pythDataList) {
         symbolToPythData[pythData.symbol] = pythData;
       }
-      const symbolToPythPriceData = await getSymbolToPythPriceData(connection, deployConfigV2.tokenInfoList);
+      const symbolToPythPriceData = await getSymbolToPythPriceData(
+        connection,
+        deployConfigV2.tokenInfoList,
+      );
       return {
         symbolToPythData,
         symbolToPythPriceData,

--- a/src/states/accounts/pythAccount.ts
+++ b/src/states/accounts/pythAccount.ts
@@ -51,8 +51,8 @@ export function getPythMarketPrice(
     poolConfig?.quote,
   );
 
-  const basePrice = getPythPrice(symbolToPythPriceData, poolConfig.base);
-  const quotePrice = getPythPrice(symbolToPythPriceData, poolConfig.quote);
+  const basePrice = getPythPrice(symbolToPythPriceData, poolConfig?.base);
+  const quotePrice = getPythPrice(symbolToPythPriceData, poolConfig?.quote);
 
   return {
     marketPrice: marketPriceTuple?.marketPrice,

--- a/src/states/accounts/pythAccount.ts
+++ b/src/states/accounts/pythAccount.ts
@@ -10,6 +10,7 @@ import {
   TokenConfig,
 } from "constants/deployConfigV2";
 import { validate } from "utils/utils";
+import { getSymbolToPythPriceData, SymbolToPythPriceData } from "anchor/pyth_utils";
 
 const MOCK_PYTH_PRODUCT_NAME_PREFIX = "Mock";
 
@@ -24,10 +25,12 @@ export type SymbolToPythData = Record<string, PythData>;
 
 export interface PythState {
   symbolToPythData: SymbolToPythData;
+  symbolToPythPriceData: SymbolToPythPriceData;
 }
 
 const initialState: PythState = {
   symbolToPythData: {},
+  symbolToPythPriceData: {},
 };
 
 export const fetchPythDataThunk = createAsyncThunk(
@@ -45,8 +48,10 @@ export const fetchPythDataThunk = createAsyncThunk(
       for (const pythData of pythDataList) {
         symbolToPythData[pythData.symbol] = pythData;
       }
+      const symbolToPythPriceData = await getSymbolToPythPriceData(connection, deployConfigV2.tokenInfoList);
       return {
         symbolToPythData,
+        symbolToPythPriceData,
       };
     } catch (e) {
       console.error(e);
@@ -58,6 +63,7 @@ export const fetchPythDataThunk = createAsyncThunk(
 export const pythAccountReducer = createReducer(initialState, (builder) => {
   builder.addCase(fetchPythDataThunk.fulfilled, (state, action) => {
     state.symbolToPythData = action.payload.symbolToPythData;
+    state.symbolToPythPriceData = action.payload.symbolToPythPriceData;
   });
 });
 

--- a/src/states/selectors.ts
+++ b/src/states/selectors.ts
@@ -22,22 +22,6 @@ export const stakeViewSelector = (state: RootState) => state.views.stakeView;
 export const gateIoSelector = (state: RootState) => state.gateIo;
 export const programSelector = (state: RootState) => state.app.program;
 
-export function selectPythPrice(symbol: string) {
-  return (state: RootState) => {
-    return getPythPrice(state.accounts.pythAccount.symbolToPythPriceData, symbol);
-  };
-}
-
-export function selectMarketPriceTuple(poolConfig: PoolConfig) {
-  return (state: RootState) => {
-    return getPythMarketPriceTuple(
-      state.accounts.pythAccount.symbolToPythPriceData,
-      poolConfig.base,
-      poolConfig.quote,
-    );
-  };
-}
-
 export function selectMarketPriceByPool(poolConfig: PoolConfig) {
   return (state: RootState) => {
     return getPythMarketPrice(state.accounts.pythAccount.symbolToPythPriceData, poolConfig);

--- a/src/states/selectors.ts
+++ b/src/states/selectors.ts
@@ -1,8 +1,7 @@
 import { RootState } from "./store";
 
-import { getPythMarketPrice, getPythPrice } from "./accounts/pythAccount";
+import { getPythMarketPrice } from "./accounts/pythAccount";
 import { getPoolConfigBySymbols, PoolConfig } from "constants/deployConfigV2";
-import { getPythMarketPriceTuple } from "anchor/pyth_utils";
 
 export const appSelector = (state: RootState) => state.app;
 export const lpUserSelector = (state: RootState) => state.accounts.liquidityProviderAccount;

--- a/src/states/selectors.ts
+++ b/src/states/selectors.ts
@@ -1,7 +1,8 @@
 import { RootState } from "./store";
 
 import { getPythMarketPrice } from "./accounts/pythAccount";
-import { getPoolConfigBySymbols, PoolConfig } from "constants/deployConfigV2";
+import { getPoolConfigBySymbols, PoolConfig, poolConfigs } from "constants/deployConfigV2";
+import { getPythMarketPriceTuple } from "anchor/pyth_utils";
 
 export const appSelector = (state: RootState) => state.app;
 export const lpUserSelector = (state: RootState) => state.accounts.liquidityProviderAccount;
@@ -20,6 +21,22 @@ export const stakeViewSelector = (state: RootState) => state.views.stakeView;
 
 export const gateIoSelector = (state: RootState) => state.gateIo;
 export const programSelector = (state: RootState) => state.app.program;
+
+export function selectPythPrice(symbol: string) {
+  return (state: RootState) => {
+    return state.accounts.pythAccount.symbolToPythPriceData[symbol].price;
+  };
+}
+
+export function selectMarketPriceTuple(poolConfig: PoolConfig) {
+  return (state: RootState) => {
+    return getPythMarketPriceTuple(
+      state.accounts.pythAccount.symbolToPythPriceData,
+      poolConfig.base,
+      poolConfig.quote,
+    );
+  };
+}
 
 export function selectMarketPriceByPool(poolConfig: PoolConfig) {
   return (state: RootState) => {

--- a/src/states/selectors.ts
+++ b/src/states/selectors.ts
@@ -1,7 +1,7 @@
 import { RootState } from "./store";
 
 import { getPythMarketPrice, getPythPrice } from "./accounts/pythAccount";
-import { getPoolConfigBySymbols, PoolConfig, poolConfigs } from "constants/deployConfigV2";
+import { getPoolConfigBySymbols, PoolConfig } from "constants/deployConfigV2";
 import { getPythMarketPriceTuple } from "anchor/pyth_utils";
 
 export const appSelector = (state: RootState) => state.app;
@@ -41,7 +41,7 @@ export function selectMarketPriceTuple(poolConfig: PoolConfig) {
 export function selectMarketPriceByPool(poolConfig: PoolConfig) {
   return (state: RootState) => {
     return getPythMarketPrice(state.accounts.pythAccount.symbolToPythPriceData, poolConfig);
-  }
+  };
 }
 
 export function selectPoolBySymbols(baseSymbol: string, quoteSymbol: string) {

--- a/src/states/selectors.ts
+++ b/src/states/selectors.ts
@@ -40,24 +40,8 @@ export function selectMarketPriceTuple(poolConfig: PoolConfig) {
 
 export function selectMarketPriceByPool(poolConfig: PoolConfig) {
   return (state: RootState) => {
-    const symbolToPythPriceData = state.accounts.pythAccount.symbolToPythPriceData;
-    const marketPriceTuple = getPythMarketPriceTuple(
-      symbolToPythPriceData,
-      poolConfig.base,
-      poolConfig.quote,
-    );
-
-    const basePrice = getPythPrice(symbolToPythPriceData, poolConfig.base);
-    const quotePrice = getPythPrice(symbolToPythPriceData, poolConfig.quote);
-
-    return {
-      marketPrice: marketPriceTuple?.marketPrice,
-      basePrice: basePrice.price,
-      quotePrice: quotePrice.price,
-      marketPriceLow: marketPriceTuple?.lowPrice,
-      marketPriceHigh: marketPriceTuple?.highPrice,
-    };
-  };
+    return getPythMarketPrice(state.accounts.pythAccount.symbolToPythPriceData, poolConfig);
+  }
 }
 
 export function selectPoolBySymbols(baseSymbol: string, quoteSymbol: string) {

--- a/src/states/selectors.ts
+++ b/src/states/selectors.ts
@@ -1,6 +1,6 @@
 import { RootState } from "./store";
 
-import { getPythMarketPrice } from "./accounts/pythAccount";
+import { getPythMarketPrice, getPythPrice } from "./accounts/pythAccount";
 import { getPoolConfigBySymbols, PoolConfig, poolConfigs } from "constants/deployConfigV2";
 import { getPythMarketPriceTuple } from "anchor/pyth_utils";
 
@@ -47,12 +47,15 @@ export function selectMarketPriceByPool(poolConfig: PoolConfig) {
       poolConfig.quote,
     );
 
+    const basePrice = getPythPrice(symbolToPythPriceData, poolConfig.base);
+    const quotePrice = getPythPrice(symbolToPythPriceData, poolConfig.quote);
+
     return {
-      marketPrice: marketPriceTuple.marketPrice,
-      basePrice: symbolToPythPriceData[poolConfig.base].price,
-      quotePrice: symbolToPythPriceData[poolConfig.quote].price,
-      marketPriceLow: marketPriceTuple.lowPrice,
-      marketPriceHigh: marketPriceTuple.highPrice,
+      marketPrice: marketPriceTuple?.marketPrice,
+      basePrice: basePrice.price,
+      quotePrice: quotePrice.price,
+      marketPriceLow: marketPriceTuple?.lowPrice,
+      marketPriceHigh: marketPriceTuple?.highPrice,
     };
   };
 }

--- a/src/states/selectors.ts
+++ b/src/states/selectors.ts
@@ -24,7 +24,7 @@ export const programSelector = (state: RootState) => state.app.program;
 
 export function selectPythPrice(symbol: string) {
   return (state: RootState) => {
-    return state.accounts.pythAccount.symbolToPythPriceData[symbol].price;
+    return getPythPrice(state.accounts.pythAccount.symbolToPythPriceData, symbol);
   };
 }
 

--- a/src/states/selectors.ts
+++ b/src/states/selectors.ts
@@ -40,7 +40,20 @@ export function selectMarketPriceTuple(poolConfig: PoolConfig) {
 
 export function selectMarketPriceByPool(poolConfig: PoolConfig) {
   return (state: RootState) => {
-    return getPythMarketPrice(state.accounts.pythAccount.symbolToPythData, poolConfig);
+    const symbolToPythPriceData = state.accounts.pythAccount.symbolToPythPriceData;
+    const marketPriceTuple = getPythMarketPriceTuple(
+      symbolToPythPriceData,
+      poolConfig.base,
+      poolConfig.quote,
+    );
+
+    return {
+      marketPrice: marketPriceTuple.marketPrice,
+      basePrice: symbolToPythPriceData[poolConfig.base].price,
+      quotePrice: symbolToPythPriceData[poolConfig.quote].price,
+      marketPriceLow: marketPriceTuple.lowPrice,
+      marketPriceHigh: marketPriceTuple.highPrice,
+    };
   };
 }
 

--- a/src/views/Dashboard/Home.tsx
+++ b/src/views/Dashboard/Home.tsx
@@ -179,7 +179,7 @@ const Home: React.FC = (props) => {
   const deltafiPrice = useSelector(selectGateIoSticker("DELFI_USDT"));
 
   const swapKeyToSwapInfo = useSelector(poolSelector).swapKeyToSwapInfo;
-  const symbolToPythData = useSelector(pythSelector).symbolToPythData;
+  const symbolToPythData = useSelector(pythSelector).symbolToPythPriceData;
   const deltafiUser = useSelector(deltafiUserSelector);
 
   const { totalHoldings, isLoadingTotalHoldings } = useMemo(() => {

--- a/src/views/Dashboard/Home.tsx
+++ b/src/views/Dashboard/Home.tsx
@@ -179,7 +179,7 @@ const Home: React.FC = (props) => {
   const deltafiPrice = useSelector(selectGateIoSticker("DELFI_USDT"));
 
   const swapKeyToSwapInfo = useSelector(poolSelector).swapKeyToSwapInfo;
-  const symbolToPythData = useSelector(pythSelector).symbolToPythPriceData;
+  const symbolToPythPriceData = useSelector(pythSelector).symbolToPythPriceData;
   const deltafiUser = useSelector(deltafiUserSelector);
 
   const { totalHoldings, isLoadingTotalHoldings } = useMemo(() => {
@@ -200,7 +200,7 @@ const Home: React.FC = (props) => {
           return res;
         }
 
-        const { basePrice, quotePrice } = getPythMarketPrice(symbolToPythData, poolConfig);
+        const { basePrice, quotePrice } = getPythMarketPrice(symbolToPythPriceData, poolConfig);
         const { baseWithdrawalAmount: baseAmount, quoteWithdrawalAmount: quoteAmount } =
           calculateWithdrawalFromShares(
             lpUser.baseShare,
@@ -225,7 +225,7 @@ const Home: React.FC = (props) => {
       return { totalHoldings, isLoadingTotalHoldings: false };
     }
     return { totalHoldings: new BigNumber(0), isLoadingTotalHoldings: false };
-  }, [symbolToPythData, swapKeyToSwapInfo, swapKeyToLpUser, isConnectedWallet]);
+  }, [symbolToPythPriceData, swapKeyToSwapInfo, swapKeyToLpUser, isConnectedWallet]);
 
   const { totalRewards, isLoadingTotalRewards } = useMemo(() => {
     // TODO(leqiang): Add farm rewards

--- a/src/views/Pool/Home.tsx
+++ b/src/views/Pool/Home.tsx
@@ -78,13 +78,13 @@ const Home: React.FC = () => {
 
   const poolState = useSelector(poolSelector);
   const pythState = useSelector(pythSelector);
-  const symbolToPythData = pythState.symbolToPythPriceData;
+  const symbolToPythPriceData = pythState.symbolToPythPriceData;
   const params = useParams<{ poolAddress?: string }>();
   const poolAddress = params?.poolAddress;
 
   const tvl = useMemo(
-    () => calculateTotalHoldings(poolConfigs, poolState.swapKeyToSwapInfo, symbolToPythData),
-    [symbolToPythData, poolState],
+    () => calculateTotalHoldings(poolConfigs, poolState.swapKeyToSwapInfo, symbolToPythPriceData),
+    [symbolToPythPriceData, poolState],
   );
 
   return (

--- a/src/views/Pool/Home.tsx
+++ b/src/views/Pool/Home.tsx
@@ -78,7 +78,7 @@ const Home: React.FC = () => {
 
   const poolState = useSelector(poolSelector);
   const pythState = useSelector(pythSelector);
-  const symbolToPythData = pythState.symbolToPythData;
+  const symbolToPythData = pythState.symbolToPythPriceData;
   const params = useParams<{ poolAddress?: string }>();
   const poolAddress = params?.poolAddress;
 


### PR DESCRIPTION
This PR refacts pyth redux state to replace old pyth logic with new utils in dex repo. This change allows us use the same code for apps, sdk and the arb bot. 