### PR TITLE
[PROD-798] Improve Value Display

### DIFF
--- a/src/lib/calc/pools.ts
+++ b/src/lib/calc/pools.ts
@@ -5,12 +5,16 @@ import { getPythMarketPrice } from "states/accounts/pythAccount";
 import { SwapPoolKeyToSwap } from "states/accounts/swapAccount";
 import { getTokenTvl } from "utils/utils";
 
-export function calculateTotalHoldings(
+export function calculateTotalValueLocked(
   poolConfigs: PoolConfig[],
   swapKeyToSwapInfo: SwapPoolKeyToSwap,
   symbolToPythPriceData: SymbolToPythPriceData,
 ) {
   if (poolConfigs.length > 0) {
+    if (Object.keys(swapKeyToSwapInfo).length < poolConfigs.length) {
+      // if the swapinfo length is less than pool config length, it means the data is not loaded yet
+      return new BigNumber(null);
+    }
     return (poolConfigs as any).reduce((sum, poolConfig) => {
       const swapInfo = swapKeyToSwapInfo[poolConfig.swapInfo];
       const { basePrice, quotePrice } = getPythMarketPrice(symbolToPythPriceData, poolConfig);

--- a/src/states/accounts/pythAccount.ts
+++ b/src/states/accounts/pythAccount.ts
@@ -77,8 +77,17 @@ export function getPythPrice(
   }
 
   const priceData = symbolToPythPriceData[tokenSymbol];
+
+  let price = priceData.price;
+  if (!price) {
+    price = priceData.previousPrice;
+  }
+  if (!price) {
+    price = priceData.aggregate.price;
+  }
+
   result = {
-    price: priceData.price,
+    price,
     confidenceInterval: priceData.confidence,
   };
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -90,3 +90,7 @@ export function formatCurrencyAmount(value: number | string | BigNumber) {
   }
   return valueBn.toNumber().toLocaleString("en-US", { style: "currency", currency: "USD" });
 }
+
+export function getValueByCondition(condition: boolean, value: any): any {
+  return condition ? value : null;
+}

--- a/src/views/Dashboard/Home.tsx
+++ b/src/views/Dashboard/Home.tsx
@@ -19,7 +19,7 @@ import {
   PoolConfig,
   poolConfigs,
 } from "constants/deployConfigV2";
-import PoolCard from "views/Pool/components/Card_v2";
+import PoolCard from "views/Pool/components/Card";
 import FarmCard from "views/Farm/components/Card";
 import { ChangeEvent, useCallback, useMemo } from "react";
 import Reward from "views/Reward";

--- a/src/views/Farm/Home.tsx
+++ b/src/views/Farm/Home.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, ReactElement, useCallback, useMemo, useState } from "react";
-import { Box, Grid, makeStyles, Theme } from "@material-ui/core";
+import { Box, CircularProgress, Grid, makeStyles, Theme } from "@material-ui/core";
 
 import Page from "components/layout/Page";
 import FarmCard from "./components/Card";
@@ -11,7 +11,7 @@ import { farmSelector, poolSelector, pythSelector, selectGateIoSticker } from "s
 import { calculateFarmPoolsStakeInfo, FarmInfoData } from "./utils";
 import BigNumber from "bignumber.js";
 import { PoolCardColor } from "utils/type";
-import { formatCurrencyAmount } from "utils/utils";
+import { formatCurrencyAmount, getValueByCondition } from "utils/utils";
 
 const useStyles = makeStyles(({ breakpoints, palette, spacing }: Theme) => ({
   container: {
@@ -247,7 +247,10 @@ const Home: React.FC = (props): ReactElement => {
       <Box className={classes.container}>
         <Box color="#fff" textAlign="center" className={classes.header}>
           <Box fontSize={36} color="#D4FF00" fontWeight={600}>
-            {formatCurrencyAmount(totalStaked)}
+            {getValueByCondition(
+              totalStaked && !totalStaked.isNaN(),
+              formatCurrencyAmount(totalStaked),
+            ) || <CircularProgress size={30} color="inherit" />}
           </Box>
           <Box marginTop={1.5} fontSize={18}>
             Total Staked

--- a/src/views/Farm/components/Card.tsx
+++ b/src/views/Farm/components/Card.tsx
@@ -164,7 +164,7 @@ const FarmCard: React.FC<CardProps> = (props) => {
         <Box marginTop={1.25}>
           <Box className={`${classes.labelTitle} ${props.color || ""}`}>APR</Box>
           <Box className={classes.label}>
-            {getValueByCondition(apr && !apr.isNaN(), convertDollar(apr.toFixed(2))) || (
+            {getValueByCondition(apr && !apr.isNaN(), `${apr.toFixed(2)}%`) || (
               <CircularProgress size={15} color="inherit" />
             )}
           </Box>

--- a/src/views/Farm/components/Card.tsx
+++ b/src/views/Farm/components/Card.tsx
@@ -1,9 +1,9 @@
 import React, { memo } from "react";
-import { Box, makeStyles } from "@material-ui/core";
+import { Box, CircularProgress, makeStyles } from "@material-ui/core";
 import styled from "styled-components";
 
 import { ConnectButton } from "components";
-import { convertDollarSign as convertDollar } from "utils/utils";
+import { convertDollarSign as convertDollar, getValueByCondition } from "utils/utils";
 import { CardProps } from "./types";
 import { useModal } from "providers/modal";
 
@@ -118,7 +118,7 @@ const useStyles = makeStyles(({ breakpoints, palette, spacing }) => ({
 
 const FarmCard: React.FC<CardProps> = (props) => {
   const classes = useStyles(props);
-  const { poolConfig, farmInfoAddress, totalStaked, userStaked, apr } = props;
+  const { poolConfig, farmInfoAddress, userStaked, totalStaked, apr } = props;
   const baseTokenInfo = poolConfig.baseTokenInfo;
   const quoteTokenInfo = poolConfig.quoteTokenInfo;
   const { setMenu } = useModal();
@@ -144,16 +144,30 @@ const FarmCard: React.FC<CardProps> = (props) => {
         {props.isUserPool && (
           <Box marginBottom={1.25}>
             <Box className={`${classes.labelTitle} ${props.color || ""}`}>My Staked</Box>
-            <Box className={classes.label}>{convertDollar(userStaked.toFixed(2))}</Box>
+            <Box className={classes.label}>
+              {getValueByCondition(
+                userStaked && !userStaked.isNaN(),
+                convertDollar(userStaked.toFixed(2)),
+              ) || <CircularProgress size={15} color="inherit" />}
+            </Box>
           </Box>
         )}
         <Box>
           <Box className={`${classes.labelTitle} ${props.color || ""}`}>Total Staked</Box>
-          <Box className={classes.label}>{convertDollar(totalStaked.toFixed(2))}</Box>
+          <Box className={classes.label}>
+            {getValueByCondition(
+              totalStaked && !totalStaked.isNaN(),
+              convertDollar(totalStaked.toFixed(2)),
+            ) || <CircularProgress size={15} color="inherit" />}
+          </Box>
         </Box>
         <Box marginTop={1.25}>
           <Box className={`${classes.labelTitle} ${props.color || ""}`}>APR</Box>
-          <Box className={classes.label}>{apr.isNaN() ? "--" : apr.toFixed(2)}%</Box>
+          <Box className={classes.label}>
+            {getValueByCondition(apr && !apr.isNaN(), convertDollar(apr.toFixed(2))) || (
+              <CircularProgress size={15} color="inherit" />
+            )}
+          </Box>
         </Box>
         <ConnectButton
           className={classes.cardBtn}

--- a/src/views/Farm/utils.ts
+++ b/src/views/Farm/utils.ts
@@ -3,6 +3,7 @@ import BigNumber from "bignumber.js";
 import { PoolConfig } from "constants/deployConfigV2";
 import { FarmPoolKeyToFarm } from "states/accounts/farmAccount";
 import { FarmPoolKeyToFarmUser } from "states/accounts/farmUserAccount";
+import { getPythPrice } from "states/accounts/pythAccount";
 import { SwapPoolKeyToSwap } from "states/accounts/swapAccount";
 import { anchorBnToBn } from "utils/tokenUtils";
 import { getTokenShareTvl, getTokenTvl } from "utils/utils";
@@ -32,9 +33,9 @@ export function calculateFarmPoolsStakeInfo(
       // null means there is no farmuser supplied explicitly
       // undefined means it is not loaded for some reason
       const farmUser = farmPoolKeyToFarmUser ? farmPoolKeyToFarmUser[farmInfoAddress] : null;
-      const basePrice = symbolToPythPriceData[poolConfig.base];
-      const quotePrice = symbolToPythPriceData[poolConfig.quote];
-
+      const basePrice = getPythPrice(symbolToPythPriceData, poolConfig.base);
+      const quotePrice = getPythPrice(symbolToPythPriceData, poolConfig.quote);
+      
       if (
         !basePrice?.price ||
         !quotePrice?.price ||

--- a/src/views/Farm/utils.ts
+++ b/src/views/Farm/utils.ts
@@ -35,7 +35,7 @@ export function calculateFarmPoolsStakeInfo(
       const farmUser = farmPoolKeyToFarmUser ? farmPoolKeyToFarmUser[farmInfoAddress] : null;
       const basePrice = getPythPrice(symbolToPythPriceData, poolConfig.base);
       const quotePrice = getPythPrice(symbolToPythPriceData, poolConfig.quote);
-      
+
       if (
         !basePrice?.price ||
         !quotePrice?.price ||

--- a/src/views/Pool/Home.tsx
+++ b/src/views/Pool/Home.tsx
@@ -1,15 +1,15 @@
 import { useMemo } from "react";
-import { Backdrop, Box, Grid, makeStyles, Modal } from "@material-ui/core";
+import { Backdrop, Box, CircularProgress, Grid, makeStyles, Modal } from "@material-ui/core";
 
 import Page from "components/layout/Page";
-import Card from "./components/Card_v2";
-import { formatCurrencyAmount } from "utils/utils";
+import Card from "./components/Card";
+import { formatCurrencyAmount, getValueByCondition } from "utils/utils";
 import { poolConfigs } from "constants/deployConfigV2";
 import { useSelector } from "react-redux";
 import { pythSelector, poolSelector } from "states/selectors";
 import { useParams } from "react-router";
 import Deposit from "views/Deposit/Deposit";
-import { calculateTotalHoldings } from "lib/calc/pools";
+import { calculateTotalValueLocked } from "lib/calc/pools";
 
 const useStyles = makeStyles(({ breakpoints, palette, spacing }) => ({
   container: {
@@ -83,7 +83,8 @@ const Home: React.FC = () => {
   const poolAddress = params?.poolAddress;
 
   const tvl = useMemo(
-    () => calculateTotalHoldings(poolConfigs, poolState.swapKeyToSwapInfo, symbolToPythPriceData),
+    () =>
+      calculateTotalValueLocked(poolConfigs, poolState.swapKeyToSwapInfo, symbolToPythPriceData),
     [symbolToPythPriceData, poolState],
   );
 
@@ -92,7 +93,9 @@ const Home: React.FC = () => {
       <Box padding={0} className={classes.container}>
         <Box color="#fff" textAlign="center" className={classes.header}>
           <Box fontSize={36} color="#D4FF00" fontWeight={600}>
-            {formatCurrencyAmount(tvl)}
+            {getValueByCondition(tvl && !tvl.isNaN(), formatCurrencyAmount(tvl)) || (
+              <CircularProgress size={30} color="inherit" />
+            )}
           </Box>
           <Box marginTop={1} fontSize={18}>
             Total Value Locked

--- a/src/views/Pool/components/Card.tsx
+++ b/src/views/Pool/components/Card.tsx
@@ -1,10 +1,14 @@
 import React, { useMemo, memo } from "react";
-import { Box, makeStyles } from "@material-ui/core";
+import { Box, CircularProgress, makeStyles } from "@material-ui/core";
 import BigNumber from "bignumber.js";
 import styled from "styled-components";
 
 import { ConnectButton } from "components";
-import { convertDollarSign as convertDollar, getTotalVolume } from "utils/utils";
+import {
+  convertDollarSign as convertDollar,
+  getTotalVolume,
+  getValueByCondition,
+} from "utils/utils";
 import { CardProps } from "./types";
 import { useSelector } from "react-redux";
 import { useModal } from "providers/modal";
@@ -205,18 +209,30 @@ const PoolCard: React.FC<CardProps> = (props) => {
         {props.isUserPool && (
           <Box marginBottom={1.25}>
             <Box className={`${classes.labelTitle} ${props.color || ""}`}>My Deposit</Box>
-            <Box className={classes.label}>{convertDollar(userTvl.toFixed(2))}</Box>
+            <Box className={classes.label}>
+              {getValueByCondition(
+                userTvl && !userTvl.isNaN(),
+                convertDollar(userTvl.toFixed(2)),
+              ) || <CircularProgress size={15} color="inherit" />}
+            </Box>
           </Box>
         )}
         <Box>
           <Box className={`${classes.labelTitle} ${props.color || ""}`}>Total Trading Volume</Box>
           <Box className={classes.label}>
-            {convertDollar(totalTradeVolume.toFixed(2).toString())}
+            {getValueByCondition(
+              totalTradeVolume && !totalTradeVolume.isNaN(),
+              convertDollar(totalTradeVolume.toFixed(2)),
+            ) || <CircularProgress size={15} color="inherit" />}
           </Box>
         </Box>
         <Box marginTop={1.25}>
           <Box className={`${classes.labelTitle} ${props.color || ""}`}>Total Deposits</Box>
-          <Box className={classes.label}>{convertDollar(tvl.toFixed(2).toString())}</Box>
+          <Box className={classes.label}>
+            {getValueByCondition(tvl && !tvl.isNaN(), convertDollar(tvl.toFixed(2).toString())) || (
+              <CircularProgress size={15} color="inherit" />
+            )}
+          </Box>
         </Box>
         <ConnectButton
           className={classes.cardBtn}

--- a/src/views/Swap/Home.tsx
+++ b/src/views/Swap/Home.tsx
@@ -68,6 +68,7 @@ import CompareArrows from "components/Svg/icons/CompareArrows";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 import { getPriceImpactDisplay } from "calculations/utils";
 import BigNumber from "bignumber.js";
+import { getPythPrice } from "states/accounts/pythAccount";
 
 const useStyles = makeStyles(({ breakpoints, palette, spacing }: Theme) => ({
   container: {
@@ -319,8 +320,8 @@ const Home: React.FC = (props) => {
 
   const getPoolTradingVolumeFromPoolConfig = useCallback(
     (poolConfig: PoolConfig) => {
-      const basePrice = new BigNumber(symbolToPythPriceData[poolConfig.base]?.price);
-      const quotePrice = new BigNumber(symbolToPythPriceData[poolConfig.quote]?.price);
+      const basePrice = new BigNumber(getPythPrice(symbolToPythPriceData, poolConfig.base).price);
+      const quotePrice = new BigNumber(getPythPrice(symbolToPythPriceData, poolConfig.quote).price);
       const baseVolume = anchorBnToBn(
         poolConfig.baseTokenInfo,
         swapKeyToSwapInfo[poolConfig.swapInfo]?.poolState?.totalTradedBase,


### PR DESCRIPTION
If the current price is unavailable, getPythPrice will use previous price or raw price value from the aggregate data
If any value in pool page and farm page is not available, it will show loading circle instead of '--' or nan
![Screen Shot 1401-04-03 at 16 13 58](https://user-images.githubusercontent.com/96594219/175744841-93a7b7bc-ab7f-4c30-9ded-f226fab6e75a.png)
![Screen Shot 1401-04-03 at 16 33 43](https://user-images.githubusercontent.com/96594219/175747548-71be8cfd-9f8f-4267-973e-41eb8c1b7947.png)
